### PR TITLE
Change to use self.__class__ in place of EasyDict for easier subclassing

### DIFF
--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -103,9 +103,9 @@ class EasyDict(dict):
 
     def __setattr__(self, name, value):
         if isinstance(value, (list, tuple)):
-            value = [EasyDict(x) if isinstance(x, dict) else x for x in value]
+            value = [self.__class__(x) if isinstance(x, dict) else x for x in value]
         else:
-            value = EasyDict(value) if isinstance(value, dict) else value
+            value = self.__class__(value) if isinstance(value, dict) else value
         super(EasyDict, self).__setattr__(name, value)
         self[name] = value
 


### PR DESCRIPTION
I had a recent need for something very similar to EasyDict but with a change to `__getattr__` behaviour. It was impossible because the current `__setattr__` refers to EasyDict directly.

This change makes subclassing friendlier :)
