### PR TITLE
Prevent copying sub-EasyDicts on assignment to fix unpickling.

### DIFF
--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -105,8 +105,8 @@ class EasyDict(dict):
         if isinstance(value, (list, tuple)):
             value = [self.__class__(x)
                      if isinstance(x, dict) else x for x in value]
-        else:
-            value = self.__class__(value) if isinstance(value, dict) else value
+        elif isinstance(value, dict) and not isinstance(value, self.__class__):
+            value = self.__class__(value)
         super(EasyDict, self).__setattr__(name, value)
         super(EasyDict, self).__setitem__(name, value)
 


### PR DESCRIPTION
This commit fixes a small bug when saving and loading EasyDicts using pickle protocol >= 2:

Normally, no matter how we refer to a subdictionary in an EasyDict, we get the same object, so their contents are synchronized.

```python
>>> foo = edict({'bar': {'bill': 'ted'}})
>>> foo.bar is foo['bar']
True
```

However, currently if we save and load an EasyDict using pickle protocol >= 2, we no longer get the same dictionary.

```python
>>> with open('foo.pkl', 'wb') as fout:
...     pickle.dump(foo, fout, protocol=2)
>>> with open('foo.pkl', 'rb') as fin:
...     fiz = pickle.load(fin)
>>> fiz.bar is fiz['bar']
False
```

The contents of these two subdicts can then become unsynchronized.

```python
>>> fiz.bar.bill = 'baz'
>>> fiz.bar.bill
'baz'
>>> fiz['bar'].bill
'ted'
```