### PR TITLE
Fix override of pop operation

### DIFF
--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -1,3 +1,5 @@
+_NO_DEFAULT = object()
+
 class EasyDict(dict):
     """
     Get attributes
@@ -138,9 +140,15 @@ class EasyDict(dict):
         for k in d:
             setattr(self, k, d[k])
 
-    def pop(self, k, d=None):
-        delattr(self, k)
-        return super(EasyDict, self).pop(k, d)
+    def pop(self, k, d=_NO_DEFAULT):
+        if d is _NO_DEFAULT:
+            result = super(EasyDict, self).pop(k)
+        else:
+            result = super(EasyDict, self).pop(k, d)
+
+        if hasattr(self, k):
+            delattr(self, k)
+        return result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This fixes a recently introduced bug that breaks the `pop` operation using default return value.

After this PR, the function will return the default value as expected and raise `KeyError` when it should (instead of `AttributeError`).

See [this discussion in StackOverflow](https://stackoverflow.com/questions/3387691/how-to-perfectly-override-a-dict) for reference.

# Before
```
In [1]: from easydict import EasyDict as edict                                                          

In [2]: a = edict({'a': 1})                                                                             

In [3]: a.pop('b')                                                                                      
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-3-f3b7e84d9f82> in <module>
----> 1 a.pop('b')

~/.virtualenvs/test/lib/python3.6/site-packages/easydict/__init__.py in pop(self, k, d)
    140 
    141     def pop(self, k, d=None):
--> 142         delattr(self, k)
    143         return super(EasyDict, self).pop(k, d)
    144 

AttributeError: b

In [4]: a.pop('b', None)                                                                                
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
<ipython-input-4-c77bf2c50a56> in <module>
----> 1 a.pop('b', None)

~/.virtualenvs/test/lib/python3.6/site-packages/easydict/__init__.py in pop(self, k, d)
    140 
    141     def pop(self, k, d=None):
--> 142         delattr(self, k)
    143         return super(EasyDict, self).pop(k, d)
    144 

AttributeError: b

In [5]: a                                                                                               
Out[5]: {'a': 1}

```

# After
```
In [1]: from easydict import EasyDict as edict                                                          

In [2]: a = edict({'a': 1})                                                                             

In [3]: a.pop('b')                                                                                      
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
<ipython-input-3-f3b7e84d9f82> in <module>
----> 1 a.pop('b')

~/.virtualenvs/test/lib/python3.6/site-packages/easydict/__init__.py in pop(self, k, d)
    143     def pop(self, k, d=_NO_DEFAULT):
    144         if d is _NO_DEFAULT:
--> 145             result = super(EasyDict, self).pop(k)
    146         else:
    147             result = super(EasyDict, self).pop(k, d)

KeyError: 'b'

In [4]: a.pop('b', None)                                                                                

In [5]: a                                                                                               
Out[5]: {'a': 1}
```
