### PR TITLE
Add support for default value for non-existent keys access

### DIFF
--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -7,12 +7,13 @@ class EasyDict(dict):
     3
     >>> d.foo
     3
-    >>> d.bar
-    Traceback (most recent call last):
-    ...
-    AttributeError: 'EasyDict' object has no attribute 'bar'
 
-    Works recursively
+    Set default value for arbitrary keys that don't exist
+    >>> d = EasyDict({'foo':3}, default_value=0)
+    >>> d['foo']
+    3
+    >>> d.bar
+    0
 
     >>> d = EasyDict({'foo':3, 'bar':{'x':1, 'y':2}})
     >>> isinstance(d.bar, dict)
@@ -105,9 +106,7 @@ class EasyDict(dict):
     >>> d.pop('a')
     4
     >>> d.a
-    Traceback (most recent call last):
-    ...
-    AttributeError: 'EasyDict' object has no attribute 'a'
+    None
     """
     def __init__(self, d=None, default_value=None, **kwargs):
         self.__default_value = default_value

--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -109,7 +109,8 @@ class EasyDict(dict):
     ...
     AttributeError: 'EasyDict' object has no attribute 'a'
     """
-    def __init__(self, d=None, **kwargs):
+    def __init__(self, d=None, default_value=None, **kwargs):
+        self.__default_value = default_value
         if d is None:
             d = {}
         if kwargs:
@@ -131,6 +132,9 @@ class EasyDict(dict):
         super(EasyDict, self).__setitem__(name, value)
 
     __setitem__ = __setattr__
+	
+    def __getattr__(self, item):
+        return self.__default_value
 
     def update(self, e=None, **f):
         d = e or dict()


### PR DESCRIPTION
Sometimes, I want to feed some parameters in functions like `params.epochs`, But it will come accross a error if `epochs` is not explicitly defined in my configuration file. The `default_value` can help to handle the conditions.