### PR TITLE
Adjusted __setattr__ to allow for derived classes; no longer causes infinite recursion problems.

### DIFF
--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -79,7 +79,7 @@ class EasyDict(dict):
 
     Simple inheritance with dict attribute
 
-    >>> class SimpleDict(EasyDict):
+    >>> class SimpleEasyDict(EasyDict):
     ...     def __init__(self):
     ...         self.value = {'one': 'two'}
     ...

--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -123,10 +123,10 @@ class EasyDict(dict):
 
     def __setattr__(self, name, value):
         if isinstance(value, (list, tuple)):
-            value = [self.__class__(x)
+            value = [EasyDict(x)
                      if isinstance(x, dict) else x for x in value]
-        elif isinstance(value, dict) and not isinstance(value, self.__class__):
-            value = self.__class__(value)
+        elif isinstance(value, dict) and not isinstance(value, EasyDict):
+            value = EasyDict(value)
         super(EasyDict, self).__setattr__(name, value)
         super(EasyDict, self).__setitem__(name, value)
 

--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -80,8 +80,8 @@ class EasyDict(dict):
     Simple inheritance with dict attribute
 
     >>> class SimpleDict(EasyDict):
-            def __init__(self):
-                self.value = {'one': 'two'}
+    ...     def __init__(self):
+    ...         self.value = {'one': 'two'}
     ...
     >>> simple_dict = SimpleEasyDict()
     >>> simple_dict['value'].one

--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -20,6 +20,7 @@ class EasyDict(dict):
     >>> d.bar.x
     1
 
+
     Bullet-proof
 
     >>> EasyDict({})
@@ -31,6 +32,7 @@ class EasyDict(dict):
     >>> d = {'a': 1}
     >>> EasyDict(**d)
     {'a': 1}
+
 
     Set attributes
 
@@ -67,20 +69,36 @@ class EasyDict(dict):
     >>> d.bar.x
     1
 
-    Still like a dict though
+
+    Still acts like a dict type
 
     >>> o = EasyDict({'clean':True})
     >>> o.items()
     [('clean', True)]
 
-    And like a class
+
+    Simple inheritance with dict attribute
+
+    >>> class SimpleDict(EasyDict):
+            def __init__(self):
+                self.value = {'one': 'two'}
+    ...
+    >>> simple_dict = SimpleEasyDict()
+    >>> simple_dict['value'].one
+    'two'
+
+
+    Static class attributes
 
     >>> class Flower(EasyDict):
     ...     power = 1
+    ...     children = {'two': 2}
     ...
     >>> f = Flower()
     >>> f.power
     1
+    >>> f.children.one
+    2
     >>> f = Flower({'height': 12})
     >>> f.height
     12
@@ -89,7 +107,32 @@ class EasyDict(dict):
     >>> sorted(f.keys())
     ['height', 'power']
 
-    update and pop items
+
+    Instance class attributes
+
+    >>> class SuperEasyDict(EasyDict):
+    ...     __init__(self, value = None):
+    ...         self.value = value
+    ...
+    >>> awesome_dict = SuperEasyDict()
+    >>> awesome_dict = SuperEasyDict(1)
+    >>> awesome_dict.value
+    1
+    >>> awesome_dict = SuperEasyDict({'gamma': 'delta', 'alpha': 'beta'})
+    >>> awesome_dict['value']
+    {'gamma': 'delta', 'alpha': 'beta'}
+    >>> sorted(awesome_dict.value.keys())
+    ['alpha', 'gamma']
+    >>> awesome_dict.value.alpha
+    'beta'
+    >>> awesome_dict.epsilon = 'zeta'
+    >>> awesome_dict['eta'] = 'theta'
+    >>> sorted(awesome_dict.keys())
+    ['epsilon', 'eta', 'value']
+
+
+    Update and pop items
+
     >>> d = EasyDict(a=1, b='2')
     >>> e = EasyDict(c=3.0, a=9.0)
     >>> d.update(e)


### PR DESCRIPTION
The implementation of __setattr__ checked against a derived class's type and constructor; this causes derived classes to infinitely recurse, trying to add the built-in elements of the class over and over (see https://github.com/makinacorpus/easydict/issues/20). This pull request fixes the problem, specifically referencing EasyDict itself instead.