### PR TITLE
more robust init

### DIFF
--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -112,6 +112,8 @@ class EasyDict(dict):
     def __init__(self, d=None, **kwargs):
         if d is None:
             d = {}
+        else:
+            d = dict(d)        
         if kwargs:
             d.update(**kwargs)
         for k, v in d.items():

--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -31,7 +31,9 @@ class EasyDict(dict):
     >>> d = {'a': 1}
     >>> EasyDict(**d)
     {'a': 1}
-
+    >>> EasyDict(('a', 1), ('b', 2))
+    {'a': 1, 'b': 2}
+    
     Set attributes
 
     >>> d = EasyDict()


### PR DESCRIPTION
This PR:

- calls `dict(...)` on the input
- adds a test case which fails if we don't do this

Specifically, because `.items()` is called on the input, if the input is eg. a `tuple(tuple(key1, value1), ..., tuple(keyN, valueN))` init raises an `AttributeError`.  Dictifying the input first avoids this.