### PR TITLE
Fix #22: Do not convert tuple attributes to list

### DIFF
--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -134,8 +134,8 @@ class EasyDict(dict):
 
     def __setattr__(self, name, value):
         if isinstance(value, (list, tuple)):
-            value = [self.__class__(x)
-                     if isinstance(x, dict) else x for x in value]
+            value = type(value)(self.__class__(x)
+                     if isinstance(x, dict) else x for x in value)
         elif isinstance(value, dict) and not isinstance(value, EasyDict):
             value = EasyDict(value)
         super(EasyDict, self).__setattr__(name, value)

--- a/easydict/__init__.py
+++ b/easydict/__init__.py
@@ -48,6 +48,12 @@ class EasyDict(dict):
     >>> d.bar.prop = 'newer'
     >>> d.bar.prop
     'newer'
+    >>> d.lst = [1, 2, 3]
+    >>> d.lst
+    [1, 2, 3]
+    >>> d.tpl = (1, 2, 3)
+    >>> d.tpl
+    (1, 2, 3)
 
 
     Values extraction


### PR DESCRIPTION
Current implementation will silently convert tuple to list. This PR reserve original type when add tuple to EasyDict 